### PR TITLE
Support oqpy index for BitVar 

### DIFF
--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -290,6 +290,11 @@ class BitVar(_SizedVar):
                 )
             else:
                 raise IndexError("list index out of range.")
+        elif isinstance(idx, IntVar):
+            return BitVar(
+                name=f"{self.name}[{idx.name}]",
+                needs_declaration=False,
+            )
         else:
             raise IndexError("The list index must be an integer.")
 

--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -36,6 +36,7 @@ from openpulse import ast
 from oqpy.base import (
     AstConvertible,
     OQPyExpression,
+    OQPyBinaryExpression,
     Var,
     make_annotations,
     map_to_ast,
@@ -290,11 +291,8 @@ class BitVar(_SizedVar):
                 )
             else:
                 raise IndexError("list index out of range.")
-        elif isinstance(idx, IntVar):
-            return BitVar(
-                name=f"{self.name}[{idx.name}]",
-                needs_declaration=False,
-            )
+        elif isinstance(idx, (OQPyBinaryExpression, IntVar)):
+            return OQIndexExpression(collection=self, index=idx)
         else:
             raise IndexError("The list index must be an integer.")
 

--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -291,7 +291,7 @@ class BitVar(_SizedVar):
                 )
             else:
                 raise IndexError("list index out of range.")
-        elif isinstance(idx, (OQPyBinaryExpression, IntVar)):
+        elif isinstance(idx, OQPyExpression) and isinstance(idx.type, ast.IntType):
             return OQIndexExpression(collection=self, index=idx)
         else:
             raise IndexError("The list index must be an integer.")

--- a/oqpy/classical_types.py
+++ b/oqpy/classical_types.py
@@ -36,7 +36,6 @@ from openpulse import ast
 from oqpy.base import (
     AstConvertible,
     OQPyExpression,
-    OQPyBinaryExpression,
     Var,
     make_annotations,
     map_to_ast,
@@ -291,7 +290,7 @@ class BitVar(_SizedVar):
                 )
             else:
                 raise IndexError("list index out of range.")
-        elif isinstance(idx, OQPyExpression) and isinstance(idx.type, ast.IntType):
+        elif isinstance(idx, OQPyExpression) and isinstance(idx.type, (ast.IntType, ast.UintType)):
             return OQIndexExpression(collection=self, index=idx)
         else:
             raise IndexError("The list index must be an integer.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "oqpy"
-version = "0.2.0"
+version = "0.2.1"
 description = "Generating OpenQASM 3 + OpenPulse in Python"
 authors = ["OQpy Contributors <oqpy-contributors@amazon.com>"]
 license = "Apache-2.0"

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -58,8 +58,9 @@ def test_variable_declaration():
     prog = Program(version=None)
     prog.declare(vars)
     prog.set(arr[1], 0)
-    prog.set(arr[IntVar(2, "index")], 1)
-    prog.set(arr[IntVar(2, "index") + 1], 0)
+    index = IntVar(2, "index")
+    prog.set(arr[index], 1)
+    prog.set(arr[index + 1], 0)
 
     with pytest.raises(IndexError):
         prog.set(arr[40], 2)
@@ -91,6 +92,7 @@ def test_variable_declaration():
         """
     ).strip()
 
+    print(prog.to_qasm())
     assert isinstance(arr[14], BitVar)
     assert prog.to_qasm() == expected
 

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -58,6 +58,7 @@ def test_variable_declaration():
     prog = Program(version=None)
     prog.declare(vars)
     prog.set(arr[1], 0)
+    prog.set(arr[IntVar(2, "index")], 1)
 
     with pytest.raises(IndexError):
         prog.set(arr[40], 2)
@@ -83,6 +84,7 @@ def test_variable_declaration():
         bit[20] arr;
         bit c;
         arr[1] = 0;
+        arr[index] = 1;
         """
     ).strip()
 

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -59,6 +59,7 @@ def test_variable_declaration():
     prog.declare(vars)
     prog.set(arr[1], 0)
     prog.set(arr[IntVar(2, "index")], 1)
+    prog.set(arr[IntVar(2, "index") + 1], 0)
 
     with pytest.raises(IndexError):
         prog.set(arr[40], 2)
@@ -75,6 +76,7 @@ def test_variable_declaration():
 
     expected = textwrap.dedent(
         """
+        int[32] index = 2;
         bool b = true;
         int[32] i = -4;
         uint[32] u = 5;
@@ -85,6 +87,7 @@ def test_variable_declaration():
         bit c;
         arr[1] = 0;
         arr[index] = 1;
+        arr[index + 1] = 0;
         """
     ).strip()
 


### PR DESCRIPTION
oqpy.BitVar indexing only allows integer index. Extend the support to oqpy.IntVar and binary operator like `i+1`. This is already implemented for ArrayVar. The implementation for BitVar mirrors the one in ArrayVar.