### PR TITLE
bug fix: fix error checking for missing type hint

### DIFF
--- a/oqpy/subroutines.py
+++ b/oqpy/subroutines.py
@@ -75,12 +75,13 @@ def subroutine(
     ) -> OQFunctionCall:
         name = func.__name__
         identifier = ast.Identifier(func.__name__)
-        argnames = list(inspect.signature(func).parameters.keys())
+        parameters = inspect.signature(func).parameters
+        argnames = list(parameters.keys())
         type_hints = get_type_hints(func)
         inputs = {}  # used as inputs when calling the actual python function
         arguments = []  # used in the ast definition of the subroutine
         for argname in argnames[1:]:  # arg 0 should be program
-            if argname not in type_hints:
+            if argname not in type_hints or type_hints[argname] is parameters[argname].empty:
                 raise ValueError(f"No type hint provided for {argname} on subroutine {name}.")
             input_ = inputs[argname] = type_hints[argname](name=argname)
 

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -1735,3 +1735,15 @@ def test_ramsey_example_blog():
     ).strip()
 
     assert full_prog.to_qasm(encal_declarations=True) == expected
+
+
+def test_subroutine_type_hints():
+    @subroutine
+    def test(prog: Program, x) -> IntVar:
+        return x
+
+    prog = Program()
+    y = IntVar(2, "y")
+
+    with pytest.raises(ValueError):
+        prog.set(y, test(prog, 3))


### PR DESCRIPTION
When type hint is missing, the argname is not missing from the `type_hints` dict, but rather the dict value is set to Parameter.empty