### PR TITLE
Reverting some unintended changes in qubit-array branch

### DIFF
--- a/oqpy/subroutines.py
+++ b/oqpy/subroutines.py
@@ -30,7 +30,7 @@ from oqpy.classical_types import OQFunctionCall, _ClassicalVar
 from oqpy.quantum_types import Qubit
 from oqpy.timing import convert_float_to_duration
 
-__all__ = ["subroutine", "annotate_subroutine", "declare_extern", "declare_waveform_generator"]
+__all__ = ["subroutine", "declare_extern", "declare_waveform_generator"]
 
 SubroutineParams = [oqpy.Program, VarArg(AstConvertible)]
 
@@ -145,7 +145,6 @@ def subroutine(
     def wrapper(
         program: oqpy.Program,
         *args: AstConvertible,
-        annotations: Sequence[str | tuple[str, str]] = (),
     ) -> OQFunctionCall:
         program.defcals.update(inner_prog.defcals)
         for name, subroutine_stmt in inner_prog.subroutines.items():
@@ -160,28 +159,6 @@ def subroutine(
 
     setattr(wrapper, "subroutine_declaration", (name, stmt))
     return wrapper
-
-
-def annotate_subroutine(keyword: str, command: str | None = None) -> Callable[[FnType], FnType]:
-    """Add annotation to a subroutine."""
-
-    def annotate_subroutine_decorator(func: FnType) -> FnType:
-        @functools.wraps(func)
-        def wrapper(
-            program: oqpy.Program,
-            *args: AstConvertible,
-            annotations: Sequence[str | tuple[str, str]] = (),
-        ) -> OQFunctionCall:
-            new_ann: str | tuple[str, str]
-            if command is not None:
-                new_ann = keyword, command
-            else:
-                new_ann = keyword
-            return func(program, *args, annotations=list(annotations) + [new_ann])
-
-        return wrapper  # type: ignore[return-value]
-
-    return annotate_subroutine_decorator
 
 
 def declare_extern(

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -216,7 +216,6 @@ def test_complex_numbers_declaration():
     _check_respects_type_hints(prog)
 
 
-
 def test_array_declaration():
     b = ArrayVar(name="b", init_expression=[True, False], dimensions=[2], base_type=BoolVar)
     i = ArrayVar(name="i", init_expression=[0, 1, 2, 3, 4], dimensions=[5], base_type=IntVar)
@@ -288,7 +287,6 @@ def test_array_declaration():
     _check_respects_type_hints(prog)
 
 
-
 def test_non_trivial_array_access():
     prog = oqpy.Program()
     port = oqpy.PortVar(name="my_port")
@@ -325,7 +323,6 @@ def test_non_trivial_array_access():
 
     assert prog.to_qasm() == expected
     _check_respects_type_hints(prog)
-
 
 
 def test_non_trivial_variable_declaration():
@@ -1850,6 +1847,7 @@ def test_in_place_subroutine_declaration():
     ).strip()
     assert prog.to_qasm() == expected
     _check_respects_type_hints(prog)
+
 
 def test_var_and_expr_matches():
     p1 = PortVar("p1")


### PR DESCRIPTION
This PR just reverts a few changes in the qubit-array branch that are the result of incorrect merges. I verified these changes against the feature/autoqasm branch of the amazon-braket-sdk-python repo and all looks good.